### PR TITLE
Submenu does not show come back situtation . and CircleZone useZ

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -245,6 +245,7 @@ RegisterNUICallback('SelectOption', function(option, cb)
                 print("No trigger setup")
             end
         end
+	MenuActive = false			
     end)
 end)
 

--- a/client/main.lua
+++ b/client/main.lua
@@ -269,7 +269,8 @@ CreateThread(function()
         for k, v in pairs(Config.CircleZones) do
             Functions:AddCircleZone(v.name, v.coords, v.radius, {
                 name = v.name,
-                debugPoly = v.debugPoly
+                debugPoly = v.debugPoly,
+		useZ = v.useZ
             }, v.menuoptions)
         end
     elseif Config.CircleZones == nil then


### PR DESCRIPTION
The problem that the submenu/secondtitle does not appear in repetitive situations. thee closeMenu(line:252 registernuicallback) part is supposed to do this actually, but for some reason it doesn't. It closes when selected but does not set the MenuActive status to false.

And when I select it, I turn it false because the menu closes.

I'm sending a video so you can better understand the problem and fix.

[Streamble-Video](https://streamable.com/didfiv)