### PR TITLE
Call 'data' Table

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -45,7 +45,7 @@ RegisterNUICallback('clickedButton', function(data)
             ExecuteCommand(data.event)
         elseif data.isQBCommand then
             TriggerServerEvent('QBCore:CallCommand', data.event, data.args)
-        elseif isAction then
+        elseif data.isAction then
             data.event(data.args)
         else
             TriggerEvent(data.event, data.args)


### PR DESCRIPTION
Apply data. table reference prior to attempting to check for isAction. No other reference to isAction variable exists in files, assumed to have meant to be in the data table.