### PR TITLE
add menuClosed Event

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -34,7 +34,11 @@ local function closeMenu()
     SendNUIMessage({
         action = 'CLOSE_MENU'
     })
+
 end
+
+RegisterNetEvent('qb-menu:client:menuClosed', function() --WKD
+end)--WKD
 
 local function showHeader(data)
     if not data or not next(data) then return end
@@ -89,6 +93,7 @@ RegisterNUICallback('closeMenu', function(_, cb)
     sendData = nil
     SetNuiFocus(false)
     cb('ok')
+    TriggerEvent('qb-menu:client:menuClosed')
 end)
 
 -- Command and Keymapping

--- a/client/main.lua
+++ b/client/main.lua
@@ -37,9 +37,6 @@ local function closeMenu()
 
 end
 
-RegisterNetEvent('qb-menu:client:menuClosed', function() --WKD
-end)--WKD
-
 local function showHeader(data)
     if not data or not next(data) then return end
     headerShown = true


### PR DESCRIPTION
Simply adds an event that fires when the menu is closed. Allowing an event handler in other scripts. Personally I use this to allow DrawText to say "[ESC] - Exit Menu" when the menu is open and '[E] - Open Menu' when its not.

- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? yes
- Does your code fit the style guidelines? yes
- Does your PR fit the contribution guidelines? yes
