### PR TITLE
Added an event to catch menu closing

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -89,6 +89,7 @@ RegisterNUICallback('closeMenu', function(_, cb)
     sendData = nil
     SetNuiFocus(false)
     cb('ok')
+    TriggerEvent("qb-menu:client:menuClosed")
 end)
 
 -- Command and Keymapping


### PR DESCRIPTION
**Describe Pull request**
Simply added a client event trigger so that you can catch menu closing in external resources.

If your PR is to fix an issue mention that issue here
When pressing your menu closing key (default ESC) there's no way for your external resource to catch this, only when pressing a menu button. An event could be used in order to fix this.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes/no] (Be honest)
Yes, trying to create a resource where an event like this is needed and I genuinely can't find a way to catch menu closing when using a closing key.
- Does your code fit the style guidelines? [yes/no]
Yes.
- Does your PR fit the contribution guidelines? [yes/no]
Yes.