### PR TITLE
feat: add optional sorting to qb-menu

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -13,7 +13,7 @@ local function sortData(data, skipfirst)
     end
     table.sort(tempData, function(a,b) return a.header < b.header end)
     if skipfirst then
-        tempData[1] = header
+        table.insert(tempData,1,header)
     end
     return tempData
 end

--- a/client/main.lua
+++ b/client/main.lua
@@ -15,7 +15,7 @@ local function sortData(data, skipfirst)
     if skipfirst then
         table.insert(tempData,1,header)
     end
-    return tempData   
+    return tempData
 end
 
 local function openMenu(data, sort, skipFirst)

--- a/client/main.lua
+++ b/client/main.lua
@@ -9,11 +9,11 @@ local function sortData(data, skipfirst)
     local header = data[1]
     local tempData = data
     if skipfirst then
-        table.remove(tempData,1)
+        tempData[1] = nil
     end
     table.sort(tempData, function(a,b) return a.header < b.header end)
     if skipfirst then
-        table.insert(tempData,1,header)
+        tempData[1] = header
     end
     return tempData
 end

--- a/client/main.lua
+++ b/client/main.lua
@@ -5,8 +5,24 @@ local headerShown = false
 local sendData = nil
 
 -- Functions
-local function openMenu(data)
+local function sortData(data, skipfirst)
+    local header = data[1]
+    local tempData = data
+    if skipfirst then
+        table.remove(tempData,1)
+    end
+    table.sort(tempData, function(a,b) return a.header < b.header end)
+    if skipfirst then
+        table.insert(tempData,1,header)
+    end
+    return tempData   
+end
+
+local function openMenu(data, sort, skipFirst)
     if not data or not next(data) then return end
+    if sort then
+        data = sortData(data, skipFirst)
+    end
 	for _,v in pairs(data) do
 		if v["icon"] then
 			local img = "qb-inventory/html/"
@@ -48,8 +64,8 @@ end
 
 -- Events
 
-RegisterNetEvent('qb-menu:client:openMenu', function(data)
-    openMenu(data)
+RegisterNetEvent('qb-menu:client:openMenu', function(data, sort, skipFirst)
+    openMenu(data, sort, skipFirst)
 end)
 
 RegisterNetEvent('qb-menu:client:closeMenu', function()


### PR DESCRIPTION
**Describe Pull request**
This PR adds an optional sort function to QB-menu. I've gotten really tired of sorting any table that lua fetches in a weird order, so would be much easier to just have qb-menu do it. 

Solved by adding a sort function and optional input fields to the sortData function.

**Added fields:**
- sort: A boolean that toggles sort on. Will sort if defined and not false.
- skipFirst: A boolean for skipping the first index in the table. Common spot used for back-buttons etc.

You can utalize the sort function like this (example from qb-vehicleshop)
![https://i.imgur.com/iW01o5k.png](https://i.imgur.com/iW01o5k.png)

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? (Be honest) Yes. Latest qb-menu.
- Does your code fit the style guidelines? Yes.
- Does your PR fit the contribution guidelines? Yes
