### PR TITLE
Final Revisit to Image on Hover [Feature]

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -14,7 +14,10 @@
     </head>
     <body>
         <div id="container">
-            <div id="buttons"></div>
+            <div id="buttons"></div>            
+            <div id="imageHover">
+                <img id="image" />
+            </div>
         </div>
     </body>
 </html>

--- a/html/script.js
+++ b/html/script.js
@@ -1,4 +1,5 @@
 let buttonParams = [];
+let images = [];
 
 const openMenu = (data = null) => {
     let html = "";
@@ -9,6 +10,7 @@ const openMenu = (data = null) => {
             let isMenuHeader = item.isMenuHeader;
             let isDisabled = item.disabled;
             let icon = item.icon;
+            images[index] = item;
             html += getButtonRender(header, message, index, isMenuHeader, isDisabled, icon);
             if (item.params) buttonParams[index] = item.params;
         }
@@ -39,6 +41,7 @@ const getButtonRender = (header, message = null, id, isMenuHeader, isDisabled, i
 const closeMenu = () => {
     $("#buttons").html(" ");
     buttonParams = [];
+    images = [];
 };
 
 const postData = (id) => {
@@ -67,6 +70,21 @@ window.addEventListener("message", (event) => {
             return;
     }
 });
+
+window.addEventListener('mousemove', (event) => {
+    let $target = $(event.target);
+    if ($target.closest('.button:hover').length && $('.button').is(":visible")) {
+        let id = event.target.id;
+        if (!images[id]) return
+        if (images[id].image) {
+            $('#image').attr('src', images[id].image);
+            $('#imageHover').css('display' , 'block');
+        }
+    }
+    else {
+        $('#imageHover').css('display' , 'none');
+    }
+})
 
 document.onkeyup = function (event) {
     const charCode = event.key;

--- a/html/script.js
+++ b/html/script.js
@@ -40,6 +40,7 @@ const getButtonRender = (header, message = null, id, isMenuHeader, isDisabled, i
 
 const closeMenu = () => {
     $("#buttons").html(" ");
+    $('#imageHover').css('display' , 'none');
     buttonParams = [];
     images = [];
 };

--- a/html/style.css
+++ b/html/style.css
@@ -174,3 +174,16 @@ div > .header {
   font-weight: 400;
   overflow: hidden;
 }
+
+#imageHover {
+    position: absolute;
+    top: 10%;
+    right: 25em;
+}
+
+#image {
+    src: "";
+    max-height: 40vh;
+    max-width: 40vw;
+    object-fit: scale-down;
+}


### PR DESCRIPTION
**Describe Pull request**
This is image on hover. You can put in an image address and when you hover that button it will display the image in the center of your screen. I have tested and retested and fixed the things that may have presented any sort of issues. Here is a good example of how I made a quick menu to demonstrate this (Would be good to add to Documentation). 

```lua
RegisterCommand('testmenu', function()
    exports['qb-menu']:openMenu({
        {
            header = 'Sub-menu button',
            txt = 'Print a message!',
            icon = 'fas fa-code-merge',
            image = 'https://cdn.pixabay.com/photo/2014/06/03/19/38/road-sign-361514_1280.png',
            params = {
                isAction = true,
                event = function(data)
                    print(data.message)
                end,
                args = {
                    message = 'This was called by clicking a button'
                }
            }
        }
    })
end)
```

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes] (Be honest)
- Does your code fit the style guidelines? [yes]
- Does your PR fit the contribution guidelines? [yes]
