### PR TITLE
Upgrade linked icon support

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -1,5 +1,5 @@
 local QBCore = exports['qb-core']:GetCoreObject()
-
+RegisterNetEvent('QBCore:Client:UpdateObject', function() QBCore = exports['qb-core']:GetCoreObject() end)
 
 local headerShown = false
 local sendData = nil
@@ -20,12 +20,10 @@ local function openMenu(data, sort, skipFirst)
     if sort then data = sortData(data, skipFirst) end
 	for _,v in pairs(data) do
 		if v["icon"] then
-			local img = "qb-inventory/html/"
 			if QBCore.Shared.Items[tostring(v["icon"])] then
-				if not string.find(QBCore.Shared.Items[tostring(v["icon"])].image, "images/") then
-					img = img.."images/"
+				if not string.find(QBCore.Shared.Items[tostring(v["icon"])].image, "//") and not string.find(v["icon"], "//") then
+                    v["icon"] = "nui://qb-inventory/html/images/"..QBCore.Shared.Items[tostring(v["icon"])].image
 				end
-				v["icon"] = img..QBCore.Shared.Items[tostring(v["icon"])].image
 			end
 		end
 	end

--- a/html/script.js
+++ b/html/script.js
@@ -27,7 +27,7 @@ const openMenu = (data = null) => {
 const getButtonRender = (header, message = null, id, isMenuHeader, isDisabled, icon) => {
     return `
         <div class="${isMenuHeader ? "title" : "button"} ${isDisabled ? "disabled" : ""}" id="${id}">
-            <div class="icon"> <img src=nui://${icon} width=30px onerror="this.onerror=null; this.remove();"> <i class="${icon}" onerror="this.onerror=null; this.remove();"></i> </div>
+            <div class="icon"> <img src=${icon} width=30px onerror="this.onerror=null; this.remove();"> <i class="${icon}" onerror="this.onerror=null; this.remove();"></i> </div>
             <div class="column">
             <div class="header"> ${header}</div>
             ${message ? `<div class="text">${message}</div>` : ""}


### PR DESCRIPTION
Due to issues with other scripts (including my own), I made it a bit more dynamic. 

- Detects wether an icon is an external link (nui:// or http://) and ignores changing it
- If the item image is a link already, ignore it
- If the icon is just an item name, create a nui link to grab the image
- Moved the "nui://" icon addition from the js file to the main.lua file
- Added the "update core" event to help with the script finding new items

**Describe Pull request**
First, make sure you've read and are following the contribution guidelines and style guide and your code reflects that.
Write up a clear and concise description of what your pull request adds or fixes and if it's an added feature explain why you think it should be included in the core.

If your PR is to fix an issue mention that issue here

Fixes QoL issues with icons being added from links

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? 
Yes
- Does your code fit the style guidelines?
I believe so
- Does your PR fit the contribution guidelines?
I believe so
