### PR TITLE
update for isAction

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -74,6 +74,11 @@ RegisterNUICallback('clickedButton', function(option, cb)
     if sendData then
         local data = sendData[tonumber(option)]
         sendData = nil
+        if data.isAction ~= nil then 
+            data.isAction()
+            cb('ok')
+            return
+        end
         if data then
             if data.params.event then
                 if data.params.isServer then
@@ -92,6 +97,7 @@ RegisterNUICallback('clickedButton', function(option, cb)
     end
     cb('ok')
 end)
+
 
 RegisterNUICallback('closeMenu', function(_, cb)
     headerShown = false


### PR DESCRIPTION
no sense in having 
```
 data[#data = 1] = {
    data.params.event[?]
}
```

if you are just utilizing a function with this PR you can do 

```
exports['qb-menu']:OpenMenu({
{
header = 'hello',
isAction = function()
 print('hello world')
end
}
})
```

**Describe Pull request**
ideally this will make things easier on devs since it will greatly reduce the tables needed to make a menu **if they are using an isAction = function() **

instead of doing

```lua
 for k, v in pairs (data) do
            jobs[#jobs + 1] = {
                header = 'Job: ' .. v.label,
                txt = 'Rank: ' .. v.rank .. ' | Salary: $' .. v.pay,
                params = {
                isServer = true,
                event =  'qb-multijob:server:changeJob',
                    args = {
                        job = v.job,
                        rank = v.level
                    }
                }   
            }
        end
 ```
 
 They can now do 
 
 ```lua
  for k, v in pairs (data) do
            jobs[#jobs + 1] = {
                header = 'Job: ' .. v.label,
                txt = 'Rank: ' .. v.rank .. ' | Salary: $' .. v.pay,
               isAction = function()
                 TriggerServerEvent('qb-multijob:server:changeJob', {job = v.job, rank = v.level})
            }
        end
```

While still maintaing the older method with a bunch of tables so it will be backwards compatible for other scripts

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes] (Be honest)
- Does your code fit the style guidelines? [yes]
- Does your PR fit the contribution guidelines? [yes]
