### PR TITLE
fix(menu): Improve menu focus handling and alt-key reliability

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -3,8 +3,14 @@ RegisterNetEvent('QBCore:Client:UpdateObject', function() QBCore = exports['qb-c
 
 local headerShown = false
 local sendData = nil
+local menuFocus = false
 
 -- Functions
+
+local function setMenuFocus(state)
+    menuFocus = state
+    SetNuiFocus(state, state)
+end
 
 local function sortData(data, skipfirst)
     local header = data[1]
@@ -27,7 +33,7 @@ local function openMenu(data, sort, skipFirst)
 			end
 		end
 	end
-    SetNuiFocus(true, true)
+    setMenuFocus(true)
     headerShown = false
     sendData = data
     SendNUIMessage({
@@ -39,7 +45,7 @@ end
 local function closeMenu()
     sendData = nil
     headerShown = false
-    SetNuiFocus(false)
+    setMenuFocus(false)
     SendNUIMessage({
         action = 'CLOSE_MENU'
     })
@@ -70,7 +76,7 @@ end)
 RegisterNUICallback('clickedButton', function(option, cb)
     if headerShown then headerShown = false end
     PlaySoundFrontend(-1, 'Highlight_Cancel', 'DLC_HEIST_PLANNING_BOARD_SOUNDS', 1)
-    SetNuiFocus(false)
+    setMenuFocus(false)
     if sendData then
         local data = sendData[tonumber(option)]
         sendData = nil
@@ -102,7 +108,7 @@ end)
 RegisterNUICallback('closeMenu', function(_, cb)
     headerShown = false
     sendData = nil
-    SetNuiFocus(false)
+    setMenuFocus(false)
     cb('ok')
     TriggerEvent("qb-menu:client:menuClosed")
 end)
@@ -110,8 +116,8 @@ end)
 -- Command and Keymapping
 
 RegisterCommand('playerfocus', function()
-    if headerShown then
-        SetNuiFocus(true, true)
+    if headerShown and not menuFocus then
+        setMenuFocus(true)
     end
 end)
 


### PR DESCRIPTION
This PR fixes an issue with the menu focus system where the alt-key functionality becomes unresponsive until script is restarted. The fix implements proper focus state tracking and centralizes focus management to ensure reliable menu interactions.

Key changes:
- Added `menuFocus` state variable to track menu focus status
- Created `setMenuFocus` function to centralize focus state management
- Modified `playerfocus` command to prevent duplicate focus attempts
- Replaced direct `SetNuiFocus` calls with the new centralized function

This fix is important for core functionality as it resolves a frustrating user experience where players need to restart the script to regain menu functionality.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes]
- Does your code fit the style guidelines? [yes]
- Does your PR fit the contribution guidelines? [yes]